### PR TITLE
Fixes for RFC3164

### DIFF
--- a/Functions/Send-SyslogMessage.ps1
+++ b/Functions/Send-SyslogMessage.ps1
@@ -277,8 +277,25 @@ Function Send-SyslogMessage
                 Write-Verbose -Message 'Using RFC 3164 message format. Maxmimum length of 1024 bytes (section 4.1)'
 
                 #Get the timestamp
-                $FormattedTimestamp = (Get-Culture).TextInfo.ToTitleCase($Timestamp.ToString('MMM dd HH:mm:ss'))
+                <#
+                    The TIMESTAMP field is the local time and is in the format of "Mmm dd
+                    hh:mm:ss" (without the quote marks) where:
+                    ...
+                    dd is the day of the month. If the day of the month is less
+                    than 10, then it MUST be represented as a space and then the
+                    number. For example, the 7th day of August would be
+                    represented as "Aug  7", with two spaces between the "g" and
+                    the "7".
+                #>
                 
+                if ($Timestamp.Day.tostring().length -eq 1) {
+                    $FormattedTimestamp = (Get-Culture).TextInfo.ToTitleCase($Timestamp.ToString('MMM  d HH:mm:ss'))
+                }
+                else
+                {
+                    $FormattedTimestamp = (Get-Culture).TextInfo.ToTitleCase($Timestamp.ToString('MMM dd HH:mm:ss'))
+                }
+
                 # Assemble the full syslog formatted Message
                 $FullSyslogMessage = '<{0}>{1} {2} {3} {4}' -f $Priority, $FormattedTimestamp, $Hostname, $ApplicationName, $Message
                 

--- a/Posh-SYSLOG.psd1
+++ b/Posh-SYSLOG.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Posh-SYSLOG.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.2.0'
+ModuleVersion = '3.2.1'
 
 # ID used to uniquely identify this module
 GUID = '6c03881f-48f0-4a55-914d-a6ee33d019e7'
@@ -104,7 +104,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'Removed dependency on NetTCPIP allowing for execution on PowerShell Core'
+        ReleaseNotes = 'Resolves issues with RFC3164 timstamp as reported by benclaussen'
     } # End of PSData hashtable
 
 } # End of PrivateData hashtable


### PR DESCRIPTION
Updated test cases to correctly test timestamp for RFC3164. Updated Send-SyslogMessage to correctly send timestamp in RFC3164 messages.

These will resolve issue #11 