### PR TITLE
Added encoding parameter

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
-	"version": "0.1.0",
+	"version": "2.0.0",
 
 	// Start PowerShell
     "windows": {
@@ -25,19 +25,11 @@
         "args": [ "-NoProfile" ]
     },
 
-	// The command is a shell script
-	"isShellCommand": true,
-
-	// Show the output window always
-	"showOutput": "always",
-
     // Associate with test task runner
     "tasks": [
         {
-            "taskName": "Test",
-            "suppressTaskName": true,
-            "isTestCommand": true,
-            "showOutput": "always",
+            "label": "Test",
+            "type": "shell",
             "args": [
                 "Write-Host 'Invoking Pester'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
@@ -45,7 +37,9 @@
             "problemMatcher": [
                 {
                     "owner": "powershell",
-                    "fileLocation": ["absolute"],
+                    "fileLocation": [
+                        "absolute"
+                    ],
                     "severity": "error",
                     "pattern": [
                         {
@@ -59,7 +53,11 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "group": {
+                "_id": "test",
+                "isDefault": false
+            }
         }
-	]
+    ]
 }

--- a/public/Send-SyslogMessage.ps1
+++ b/public/Send-SyslogMessage.ps1
@@ -51,6 +51,14 @@ public enum Syslog_Protocol
 }
 "@
 
+Add-Type -TypeDefinition @"
+public enum Syslog_Encoding
+{
+    ASCII,
+    UTF8
+}
+"@
+
 Function Send-SyslogMessage
 {
     <#
@@ -161,6 +169,13 @@ Function Send-SyslogMessage
         [Syslog_Protocol]
         $Transport = 'UDP',
 
+        # Encoding charset (ASCII or UTF8) to be used when sending the message. Default is ASCII.
+        [Parameter(Mandatory                        = $false,
+                   ValueFromPipelineByPropertyName  = $true)]
+        [ValidateNotNullOrEmpty()]
+        [Syslog_Encoding]
+        $Encoding = 'ASCII',
+
         #ProcessID or PID of generator of message. Will automatically use $PID global variable. If you want to override this and send null, specify '-' to meet RFC 5424 rquirements.
         [Parameter(Mandatory                        = $false,
                    ValueFromPipelineByPropertyName  = $true,
@@ -219,7 +234,7 @@ Function Send-SyslogMessage
         Write-Debug -Message 'Starting the BEGIN block...'
 
         # Create an ASCII Encoding object
-        $Encoding = [Text.Encoding]::ASCII
+        $EncodingText = [Text.Encoding]::$Encoding
 
         # Initiate the required network objects
         Switch ($Transport)
@@ -365,7 +380,7 @@ Function Send-SyslogMessage
         Write-Verbose -Message ('Message attempting to send is: {0}' -f $FullSyslogMessage)
 
         # Ensure that the message is not too long. We could just compare the strings length, however using the encoding is the more appropriate way of confirming the length in bytes.
-        if ($Encoding.GetByteCount($FullSyslogMessage) -gt $MaxLength)
+        if ($EncodingText.GetByteCount($FullSyslogMessage) -gt $MaxLength)
         {
             $FullSyslogMessage = $FullSyslogMessage.Substring(0,$MaxLength)
             Write-Verbose -Message ('Message was too long and was shortened to {0} characters' -f $MaxLength)
@@ -377,7 +392,7 @@ Function Send-SyslogMessage
             'UDP'
             {
                 # Convert into byte array representation
-                $ByteSyslogMessage = $Encoding.GetBytes($FullSyslogMessage)
+                $ByteSyslogMessage = $EncodingText.GetBytes($FullSyslogMessage)
 
                 # Send the Message
                 Try
@@ -402,7 +417,7 @@ Function Send-SyslogMessage
                 {
                     'Octet-Counting'
                     {
-                        $OctetCount = ($Encoding.GetBytes($FullSyslogMessage)).Length
+                        $OctetCount = ($EncodingText.GetBytes($FullSyslogMessage)).Length
                         $FramedSyslogMessage = '{0} {1}' -f $OctetCount, $FullSyslogMessage
                         Write-Verbose -Message ('Octet-Counting - Framed message is: {0}' -f $FullSyslogMessage)
                     }
@@ -421,7 +436,7 @@ Function Send-SyslogMessage
                 }
 
                 # Convert into byte array representation
-                $ByteSyslogMessage = $Encoding.GetBytes($FramedSyslogMessage)
+                $ByteSyslogMessage = $EncodingText.GetBytes($FramedSyslogMessage)
 
                 # Send the Message
                 Try

--- a/public/Send-SyslogMessage.ps1
+++ b/public/Send-SyslogMessage.ps1
@@ -233,8 +233,18 @@ Function Send-SyslogMessage
     {
         Write-Debug -Message 'Starting the BEGIN block...'
 
-        # Create an ASCII Encoding object
-        $EncodingText = [Text.Encoding]::$Encoding
+        # Create an Encoding object
+        Switch ($Encoding)
+        {
+            'ASCII' {
+                Write-Verbose -Message 'Selected Encoding is ASCII'
+                $EncodingText = [System.Text.Encoding]::ASCII
+            }
+            'UTF8'  {
+                Write-Verbose -Message 'Selected Encoding is UTF8'
+                $EncodingText = [System.Text.Encoding]::UTF8
+            }
+        }
 
         # Initiate the required network objects
         Switch ($Transport)


### PR DESCRIPTION
### Requirements

* [x] Written new test cases to ensure no regression bugs occur?
* [x] Ensured all test cases are now passing?
* [x] Ensured that PowerShell Script Analyser issues and warnings are completely resolved?
* [x] Updated any help or documentation that may be impacted by your changes?

### Description of the Change

Added the ability to specify the Encoding parameter to choose between ASCII or UTF8 encoding. If the parameter is not specified, ASCII will be used by default. Specifying this parameter is important when the message text contains non-ASCII characters. Without it, the received message may be displayed incorrectly. For example, the text might be displayed as "?" characters.
Usage example:
Send-SyslogMessage -Server hostname -Message "Test" -Severity Alert -Facility local0 -Encoding UTF8
This command will send a message using UTF8 encoding.

### Testing

The tests verify the correct encoding of non-ASCII characters after converting back to text.

### Associated/Resolved Issues

Wrong non-ASCII chars in messages.
